### PR TITLE
Update the listing for Beaker 

### DIFF
--- a/camp/content/_index.md
+++ b/camp/content/_index.md
@@ -9,7 +9,7 @@ Here are some of our featured projects and events:
 
 {{< campticks >}}
 * [I2P](https://geti2p.net/)
-* [DAT & Beaker Browser](https://beakerbrowser.com/)
+* [Beaker Browser](https://beakerbrowser.com/)
 * [IPFS](https://ipfs.io/)
 * [WebTorrent](https://webtorrent.io/)
 * Sunday Unconference and Participant Showcase

--- a/camp/public/index.html
+++ b/camp/public/index.html
@@ -268,7 +268,7 @@ Here are some of our featured projects and events:</p>
 <div class="campticks">
   <ul>
 <li><a href="https://geti2p.net/">I2P</a></li>
-<li><a href="https://beakerbrowser.com/">DAT &amp; Beaker Browser</a></li>
+<li><a href="https://beakerbrowser.com/">Beaker Browser</a></li>
 <li><a href="https://ipfs.io/">IPFS</a></li>
 <li><a href="https://webtorrent.io/">WebTorrent</a></li>
 <li>Sunday Unconference and Participant Showcase</li>


### PR DESCRIPTION
We've rebranded the tech for Beaker to Hypercore, and I figure it'd be simpler to just say Beaker.